### PR TITLE
Add optional :cloudbees-api-url project key for configuring api endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+== Changes between versions 1.0.4 and 1.0.5
+
+Version 1.0.5 introduces no breaking change.
+
+=== Features
+
+- Addition of a `project.clj` key, `:cloudbees-api-url`, for configuring api endpoints beyond the default one
+
+    ```clojure
+    (defproject
+      ...
+      ; for European region
+      :cloudbees-api-url "https://api-eu.cloudbees.com/api"
+      ... )
+    ```

--- a/README
+++ b/README
@@ -27,6 +27,8 @@ Use ~(slurp file) to read in your cloudbees credentials - DO NOT PUT THEM DIRECT
 
 If you use the cloudbees SDK - it will read the credentials from ~/.bees/bees.config as normal (bees.api.key and bees.api.secret entries in that file, specifically).
 
+If your application is running in European region, override the default api endpoint by setting the `:cloudbees-api-url` key in the project map. e.g. `:cloudbees-api-url "https://api-eu.cloudbees.com/api"`.
+
 ## License
 
 Copyright (C) 2011 Michael Neale

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-cloudbees "1.0.4"
+(defproject lein-cloudbees "1.0.5"
   :description "Cloudbees lein deployment plugin for deploying your special snowflake apps really really easily.
   See https://github.com/michaelneale/lein-cloudbees for docs and installation instructions.
   (when installed type lein cloudbees to see what you can do. For any ring based webapps."

--- a/src/leiningen/cloudbees.clj
+++ b/src/leiningen/cloudbees.clj
@@ -7,7 +7,7 @@
 
 (defn- cb-client [project]
   (doto (new com.cloudbees.api.BeesClient
-          endpoint
+          (or (:cloudbees-api-url project) endpoint)
           (:cloudbees-api-key project)
           (:cloudbees-api-secret project)
           "xml"


### PR DESCRIPTION
Hello, 

Working with Europe zone, I had the need to make Europe zone accessible.

I hope you find I've respected the spirit of the keys naming, etc.

Cheers,
## 

Laurent
